### PR TITLE
Added a callback to manage when Karma exist, needed on Linux

### DIFF
--- a/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
+++ b/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
@@ -15,6 +15,10 @@ export default () => (targets, { options: { grep, watch } }) => () => {
             rocBuilder.buildConfig
         );
 
-        new Server(karmaConfig).start();
+        new Server(karmaConfig, (exitCode) => {
+            /* eslint-disable no-process-exit */
+            process.exit(exitCode);
+            /* eslint-enable */
+        }).start();
     }
 };


### PR DESCRIPTION
Seems like this fixes the problem that Karma finishes with exit code 141 on Linux when using PhantomJS.
