### PR TITLE
listen for SIGPIPE as a workaround to make the test not return 141

### DIFF
--- a/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
+++ b/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
@@ -15,6 +15,10 @@ export default () => (targets, { options: { grep, watch } }) => () => {
             rocBuilder.buildConfig
         );
 
+        // TODO: Solve this workaround. If we don't listen for SIGPIPE and the
+        // SIGPIPE times out, it will return an exit code 141.
+        process.on('SIGPIPE', () => {});
+
         new Server(karmaConfig, (exitCode) => {
             /* eslint-disable no-process-exit */
             process.exit(exitCode);

--- a/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
+++ b/packages/roc-plugin-test-mocha-karma-webpack/src/actions/test.js
@@ -17,6 +17,8 @@ export default () => (targets, { options: { grep, watch } }) => () => {
 
         // TODO: Solve this workaround. If we don't listen for SIGPIPE and the
         // SIGPIPE times out, it will return an exit code 141.
+        // This only happens on Linux and seems to be related to Socket.io not closing down.
+        // See issue #2 for more information about this.
         process.on('SIGPIPE', () => {});
 
         new Server(karmaConfig, (exitCode) => {


### PR DESCRIPTION
Temporary solution to #2 
